### PR TITLE
Removing not allowed characters from module names before saving content

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,8 @@ const app = (() => {
             });
         const { url } = resAsset.data.elements[0].url;
         const fileName = `${padZero(assetNum)} - ${resAsset.data.elements[0].name}`;
-        const directory = path.join('.', _cid, 'Week ' + padZero(weekNum), padZero(moduleNum) + ' - ' + module.name);
+        const moduleName = module.name.replace(/[\/\:*?"<>|+]/g, ' ');
+        const directory = path.join('.', _cid, 'Week ' + padZero(weekNum), padZero(moduleNum) + ' - ' + moduleName);
         const downloader = new Downloader({ url, directory, fileName, cloneFiles: false, timeout: 300000 });
         await downloader.download();
         log(`      ${chalk.white('Asset')} ${chalk.green(`#${padZero(assetNum)} - Saved '${fileName}'`)}`);


### PR DESCRIPTION
I tried to download Coursera content with the scraper, but it kept failing on writing asset files to disk on Windows. I've removed special characters from module names while saving assets as well.